### PR TITLE
Make PEP585 type annotations backwards compatible with Python 3.7+

### DIFF
--- a/src/dotenv_vault/main.py
+++ b/src/dotenv_vault/main.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import os
 import logging
 from typing import (IO, Optional,Union)

--- a/src/dotenv_vault/vault.py
+++ b/src/dotenv_vault/vault.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import os
 import io
 


### PR DESCRIPTION
Resolves issue #5 ,

Makes type annotations confirming to PEP585 work with Python 3.7+. E.g. the following:
`list[dict]`

Reference on this change: https://peps.python.org/pep-0585/
