### PR TITLE
Fix build problem; add license file

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,23 @@
+Copyright (c) 2023 Scott Motte
+
+MIT License
+
+Permission is hereby granted, free of charge, to any person obtaining
+a copy of this software and associated documentation files (the
+"Software"), to deal in the Software without restriction, including
+without limitation the rights to use, copy, modify, merge, publish,
+distribute, sublicense, and/or sell copies of the Software, and to
+permit persons to whom the Software is furnished to do so, subject to
+the following conditions:
+
+The above copyright notice and this permission notice shall be
+included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+

--- a/Makefile
+++ b/Makefile
@@ -13,6 +13,7 @@ clean-pyc:
 	find . -name '*~' -exec rm -f {} +
 
 build: clean
+	pip install build
 	python -m build
 
 uninstall_local:

--- a/src/dotenv_vault/__version__.py
+++ b/src/dotenv_vault/__version__.py
@@ -1,7 +1,7 @@
 __title__ = "python-dotenv-vault"
 __description__ = "Decrypt .env.vault file."
 __url__ = "https://github.com/dotenv-org/python-dotenv-vault"
-__version__ = "0.5.1"
+__version__ = "0.5.2"
 __author__ = "dotenv"
 __author_email__ = "mot@dotenv.org"
 __license__ = "MIT"


### PR DESCRIPTION
- Install the `build` package as part of the `build` goal in the makefile.
- Add the same license as for the Go package.