### PR TITLE
Fix loading issue

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file. See [standa
 
 ## [Unreleased](https://github.com/dotenv-org/python-dotenv-vault/compare/v0.5.1...master)
 
+## 0.6.0
+
+### Changed
+
+- Fix environment variable load [#12](https://github.com/dotenv-org/python-dotenv-vault/pull/12)
+
 ## 0.5.1
 
 ### Changed

--- a/src/dotenv_vault/__version__.py
+++ b/src/dotenv_vault/__version__.py
@@ -1,7 +1,7 @@
 __title__ = "python-dotenv-vault"
 __description__ = "Decrypt .env.vault file."
 __url__ = "https://github.com/dotenv-org/python-dotenv-vault"
-__version__ = "0.5.2"
+__version__ = "0.6.0"
 __author__ = "dotenv"
 __author_email__ = "mot@dotenv.org"
 __license__ = "MIT"

--- a/src/dotenv_vault/main.py
+++ b/src/dotenv_vault/main.py
@@ -15,7 +15,7 @@ def load_dotenv(
     dotenv_path: Union[str, os.PathLike, None] = None,
     stream: Optional[IO[str]] = None,
     verbose: bool = False,
-    override: bool = False,
+    override: bool = True,
     interpolate: bool = True,
     encoding: Optional[str] = "utf-8",
 ) -> bool:
@@ -42,7 +42,6 @@ def load_dotenv(
     if "DOTENV_KEY" in os.environ:
         vault_stream = parse_vault(open(".env.vault"))
         return dotenv.load_dotenv(
-            dotenv_path=".env.vault",
             stream=vault_stream,
             verbose=verbose,
             override=override,

--- a/src/dotenv_vault/test_vault.py
+++ b/src/dotenv_vault/test_vault.py
@@ -2,7 +2,7 @@ from io import StringIO
 import os
 import unittest
 
-from dotenv.main import DotEnv
+from dotenv.main import load_dotenv
 
 import dotenv_vault.main as vault
 
@@ -40,19 +40,23 @@ class TestParsing(unittest.TestCase):
                 if old_dotenv_key:
                     os.environ["DOTENV_KEY"] = old_dotenv_key
 
-    PARSE_TEST_KEY = "dotenv://:key_0dec82bea24ada79a983dcc11b431e28838eae59a07a8f983247c7ca9027a925@dotenv.local/vault/.env.vault?environment=development"
+    PARSE_TEST_KEY = "dotenv://:key_ff6456d445b08c289eec891ba1944e3ae09b00b33387d046624214aff27173d5@dotenv.org/vault/.env.vault?environment=production"
 
-    PARSE_TEST_VAULT = """# .env.vault (generated with npx dotenv-vault local build)
-                        DOTENV_VAULT_DEVELOPMENT="H2A2wOUZU+bjKH3kTpeua9iIhtK/q7/VpAn+LLVNnms+CtQ/cwXqiw=="
-                        """
+    PARSE_TEST_VAULT = """
+    DOTENV_VAULT=vlt_993de4634508b7d119adc8010781346341a142250aa1df5a20ad53bf0d9d8992
+    DOTENV_VAULT_DEVELOPMENT="BINHFMl8zRRSt5cLMe9BNHDdsH1D5zX45tRrL05WYYbXCuBDsLF2YiAT7VKDdrbk1eg/X5n4FKO76lE1UQ5QTA=="
+    DOTENV_VAULT_CI="nWcJP28Z7w16aBuh9sg/zFACTqWcBXgJnykPNDkF7RqjOwESQDFSO5cymC4="
+    DOTENV_VAULT_STAGING="uGHOx986lAWGU9s5mN5+b0jl0HAvNj4Mqs/zwN7Bl8UeV+C6hBg5JuKdi2AGGLka5g=="
+    DOTENV_VAULT_PRODUCTION="YpDpGGf+eqiOPibziIQQbw4gBW/zfOBR6jow5B1UHYTTu6Kak6xy+qP/vXZWaPp4HOh2/Nu7gRK2CWfrbtk="
+    """
                 
     def test_vault_parsing(self):
         old_dotenv_key = os.environ.get("DOTENV_KEY")
         os.environ["DOTENV_KEY"] = self.PARSE_TEST_KEY
         try:
             stream = vault.parse_vault(StringIO(self.PARSE_TEST_VAULT))
-            dotenv = DotEnv(dotenv_path=".env.vault", stream=stream)
-            self.assertEqual(dotenv.dict().get("HELLO"), "world")
+            load_dotenv(stream=stream, override=True)
+            self.assertEqual(os.environ.get("HELLO"), "Production")
         finally:
             os.unsetenv("DOTENV_KEY")
             if old_dotenv_key:


### PR DESCRIPTION
we need to allow override to be True by default because frameworks like Django and Flask load `dotenv` at startup. So we need to allow `dotenv_vault` to override it. 

Also, if we use stream, we don't want to also load the file. This caused the environment variable not to load properly.