### PR TITLE
bump cryptography above 41.0.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file. See [standa
 
 ## [Unreleased](https://github.com/dotenv-org/python-dotenv-vault/compare/v0.5.1...master)
 
+## 0.6.4
+
+### Changed
+
+- Bump Cryptography above 41.0.3 to resolve [#19](https://github.com/dotenv-org/python-dotenv-vault/issues/19) ([Vulnerable OpenSSL included in cryptography wheels](https://github.com/advisories/GHSA-5cpq-8wj7-hf2v) and [pyca/cryptography's wheels include vulnerable OpenSSL](https://github.com/advisories/GHSA-jm77-qphf-c4w8))
+
 ## 0.6.3
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ All notable changes to this project will be documented in this file. See [standa
 
 ### Changed
 
-- Bump Cryptography above 41.0.3 to resolve [#19](https://github.com/dotenv-org/python-dotenv-vault/issues/19) ([Vulnerable OpenSSL included in cryptography wheels](https://github.com/advisories/GHSA-5cpq-8wj7-hf2v) and [pyca/cryptography's wheels include vulnerable OpenSSL](https://github.com/advisories/GHSA-jm77-qphf-c4w8))
+- Bump Cryptography above 41.0.3 to resolve [#19](https://github.com/dotenv-org/python-dotenv-vault/issues/19) (High severity [CVE-2023-38325](https://nvd.nist.gov/vuln/detail/CVE-2023-38325))
 
 ## 0.6.3
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,2 @@
 python-dotenv~=0.21.0
-cryptography<41.0.0,>=3.1.0
+cryptography<42.0.0,>41.0.3

--- a/setup.py
+++ b/setup.py
@@ -40,6 +40,6 @@ setup(
     ],
     install_requires=[
         'python-dotenv~=0.21.0',
-        'cryptography<41.0.0,>=3.1.0'
+        'cryptography<42.0.0,>41.0.3'
     ],
 )

--- a/src/dotenv_vault/__version__.py
+++ b/src/dotenv_vault/__version__.py
@@ -1,7 +1,7 @@
 __title__ = "python-dotenv-vault"
 __description__ = "Decrypt .env.vault file."
 __url__ = "https://github.com/dotenv-org/python-dotenv-vault"
-__version__ = "0.6.3"
+__version__ = "0.6.4"
 __author__ = "dotenv"
 __author_email__ = "mot@dotenv.org"
 __license__ = "MIT"


### PR DESCRIPTION
resolves #19 
adds additional tests (load_dotenv() is now tested)