### PR TITLE
fix: correct fallback with no key no `.env` file

### DIFF
--- a/src/dotenv_vault/main.py
+++ b/src/dotenv_vault/main.py
@@ -65,7 +65,8 @@ def load_dotenv(
         )
     else:
         dotenv_path = dotenv.find_dotenv(usecwd=True)
-        stream = open(dotenv_path) if not stream else stream
+        if not stream:
+            stream = open(dotenv_path) if dotenv_path else None
         return dotenv.load_dotenv(
             stream=stream, 
             verbose=verbose, 


### PR DESCRIPTION
Fixes the fall back behavior when no key is provided and no `.env` file is found. The previous implementation was raising an exception due to opening a file that does not exist.

Fixes: #27