### PR TITLE
Loosen dependency version restrictions and remove support for PY3.7

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,7 +8,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ["3.7", "3.8", "3.9", "3.10", "3.11"]
+        python-version: ["3.8", "3.9", "3.10", "3.11", "3.12", "3.13"]
 
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,9 +11,9 @@ jobs:
         python-version: ["3.8", "3.9", "3.10", "3.11", "3.12", "3.13"]
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v5
         with:
           python-version: ${{ matrix.python-version }}
       - name: Install dependencies

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,13 @@ All notable changes to this project will be documented in this file. See [standa
 
 ## [Unreleased](https://github.com/dotenv-org/python-dotenv-vault/compare/v0.6.4...master)
 
+## 0.7.0
+### Changed
+
+- Update dependencies python-dotenv and cryptography
+- Remove support for Python 3.7
+
+
 ## 0.6.4
 
 ### Changed

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,2 @@
-python-dotenv~=1.1.1
-cryptography>=45.0.0
+python-dotenv>=0.21.0
+cryptography>=41.0.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,2 @@
-python-dotenv~=0.21.0
-cryptography<42.0.0,>41.0.3
+python-dotenv~=1.1.1
+cryptography>=45.0.0

--- a/setup.py
+++ b/setup.py
@@ -39,7 +39,7 @@ setup(
     'dotenv-vault'
     ],
     install_requires=[
-        'python-dotenv~=1.1.1',
-        'cryptography>=45.0.0'
+        'python-dotenv>=0.21.0',
+        'cryptography>=41.0.0'
     ],
 )

--- a/setup.py
+++ b/setup.py
@@ -39,7 +39,7 @@ setup(
     'dotenv-vault'
     ],
     install_requires=[
-        'python-dotenv~=0.21.0',
-        'cryptography<42.0.0,>41.0.3'
+        'python-dotenv~=1.1.1',
+        'cryptography>=45.0.0'
     ],
 )


### PR DESCRIPTION
This PR relaxes the version requirements so that the package can be used with other packages which require newer versions of cryptography.

Note: removes support py3.7 because this is [not provided on the `ubuntu-latest` image](https://raw.githubusercontent.com/actions/python-versions/main/versions-manifest.json).

This also tests against py 3.12 and 3.13.

fixes #21 